### PR TITLE
Add support for handling already decompressed responses

### DIFF
--- a/stackexchange/web.py
+++ b/stackexchange/web.py
@@ -92,9 +92,16 @@ class WebRequestManager(object):
 
 		req_data = conn.read()
 
-		data_stream = StringIO.StringIO(req_data)
-		gzip_stream = gzip.GzipFile(fileobj=data_stream)
-		actual_data = gzip_stream.read()
+		# Handle compressed responses.
+		# (Stack Exchange's API sends its responses compressed but intermediary
+		# proxies may send them to us decompressed.)
+		if conn.info().getheader('Content-Encoding') == 'gzip':
+			data_stream = StringIO.StringIO(req_data)
+			gzip_stream = gzip.GzipFile(fileobj=data_stream)
+
+			actual_data = gzip_stream.read()
+		else:
+			actual_data = req_data
 
 		info = conn.info()
 		conn.close()


### PR DESCRIPTION
Some intermediary proxies might send us the API's response decompressed. With this pull request we now account for that by only decompressing the response if its `Content-Encoding` header is `gzip`.
