### PR TITLE
Answer.title no longer included by default; dropped from __unicode__()

### DIFF
--- a/stackexchange/__init__.py
+++ b/stackexchange/__init__.py
@@ -79,7 +79,7 @@ class Answer(JSONModel):
 		return site.answer(self.id)
 
 	def __unicode__(self):
-		return u'Answer %d [%s]' % (self.id, self.title)
+		return u'Answer %d' % self.id
 
 	def __str__(self):
 		return str(unicode(self))


### PR DESCRIPTION
This does alas make `Answer.__unicode__()` a little less useful, but I saw no other fields of relevance included in [the default filter for answer](https://api.stackexchange.com/docs/types/answer).

Given that one can use filters to eliminate all fields, then maybe I should patch all objects' `__unicode__` to make no key assumptions - thoughts?
