### PR TITLE
Fix for window calculation when throttling

### DIFF
--- a/stackexchange/web.py
+++ b/stackexchange/web.py
@@ -73,7 +73,7 @@ class WebRequestManager(object):
 
 		# Before we do the actual request, are we going to be throttled?
 		if self.impose_throttling:
-			if (WebRequestManager.window - now).seconds >= 5:
+			if (now - WebRequestManager.window).seconds >= 5:
 				WebRequestManager.window = now
 				WebRequestManager.num_requests = 0
 			WebRequestManager.num_requests += 1


### PR DESCRIPTION
Here's another one for you :) As `now` will be after when the window started we need to subtract from `now` rather than `window`.

In case you're interested, I'm using the library to update the database for this - http://stackapps.com/questions/3520/stackdoc-adding-stack-overflow-data-to-online-documentation. That means I'm pulling down all the questions that have been updated since the last data dump, which is giving the throttling code a good test run!
