### PR TITLE
Fix run instructions in demo comments

### DIFF
--- a/demo/experience.py
+++ b/demo/experience.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-# a hack so you can run it 'python demo/stats.py'
+# a hack so you can run it 'python demo/experience.py'
 import sys
 sys.path.append('.')
 sys.path.append('..')

--- a/demo/highest_voted.py
+++ b/demo/highest_voted.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-# a hack so you can run it 'python demo/stats.py'
+# a hack so you can run it 'python demo/highest_voted.py'
 import sys
 sys.path.append('.')
 sys.path.append('..')

--- a/demo/narcissism.py
+++ b/demo/narcissism.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-# a hack so you can run it 'python demo/stats.py'
+# a hack so you can run it 'python demo/narcissism.py'
 import sys
 sys.path.append('.')
 sys.path.append('..')

--- a/demo/search.py
+++ b/demo/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-# a hack so you can run it 'python demo/stats.py'
+# a hack so you can run it 'python demo/search.py'
 import sys
 sys.path.append('.')
 sys.path.append('..')


### PR DESCRIPTION
Possibly due to a copying/pasting mistake,
a few demo scripts said to run demo/stats.py
instead of their own names.