### PR TITLE
Add moderators_elected method to Site

### DIFF
--- a/list-of-methods.txt
+++ b/list-of-methods.txt
@@ -286,6 +286,7 @@ Site(domain, app_key = None, cache = 1800):
 	users(ids = [], **) @users @users-by-ids
 	users_by_name(name, **)
 	moderators(**) @moderators
+	moderators_elected(**) @elected-moderators
 	answer(nid, **) @answers-by-ids
 	answers(ids = None, **) @answers @answers-by-ids
 	comment(nid, **) @comments-by-ids

--- a/stackexchange/site.py
+++ b/stackexchange/site.py
@@ -229,6 +229,10 @@ through here."""
         """Retrieves a list of the moderators on the site."""
         return self.build('users/moderators', User, 'users', kw)
 
+    def moderators_elected(self, **kw):
+        """Retrieves a list of the elected moderators on the site."""
+        return self.build('users/moderators/elected', User, 'users', kw)
+
     def answer(self, nid, **kw):
         """Retrieves an object describing the answer with the ID `nid`."""
         a, = self.answers((nid,), **kw)


### PR DESCRIPTION
Unless I'm crazy, there's no method to get only the elected moderators of a site, excluding SE employees with diamond privileges. So I added one. 