### PR TITLE
Fixed Period typo

### DIFF
--- a/list-of-methods.txt
+++ b/list-of-methods.txt
@@ -119,7 +119,7 @@ TagWiki:
 	excerpt_editor = User.partial(last_excerpt_editor['user_id'])
 
 Period(Enumeration):
-	AllTime = 'all-time'
+	AllTime = 'all_time'
 	Month = 'month'
 
 TopUser:


### PR DESCRIPTION
for AllTime, you would pass 'all_time' instead of 'all-time' with an underscore and not a hyphen. Little typo.