### PR TITLE
Add is_employee field to the User model

### DIFF
--- a/stackexchange/models.py
+++ b/stackexchange/models.py
@@ -343,7 +343,7 @@ class User(JSONModel):
     """Describes a user on a StackExchange site."""
     transfer = ('display_name', 'profile_image', 'age', 'website_url',
         'location', 'about_me', 'view_count', 'up_vote_count',
-        'down_vote_count', 'account_id', 'profile_image',
+        'down_vote_count', 'account_id', 'profile_image', 'is_employee',
         ('creation_date', UNIXTimestamp),
         ('last_access_date', UNIXTimestamp),
         ('reputation', FormattedReputation),


### PR DESCRIPTION
I added the `is_employee` field to the User model, since it's part of the returned JSON (in API 2.2) but wasn't accounted for in this code, as far as I could tell. I need this to get lists of appointed moderators on beta sites; the API doesn't provide an endpoint for that, I have to do it by getting the list of all mods and filtering out employees and Community. I thought this might be a good addition to the code.