### PR TITLE
docs: Fix a few typos

### DIFF
--- a/stackexchange/site.py
+++ b/stackexchange/site.py
@@ -292,7 +292,7 @@ unlike on the actual site, you will receive an error rather than a redirect to t
         return self.build('badges', Badge, 'badges', kw)
 
     def badges(self, ids = None, **kw):
-        """Returns the badge objectss with the given IDs."""
+        """Returns the badge objects with the given IDs."""
         if ids == None:
             return self._user_prop('badges', Badge, 'users', kw)
         else:

--- a/testsuite.py
+++ b/testsuite.py
@@ -3,7 +3,7 @@ import logging
 import datetime, re, stackauth, stackexchange, stackexchange.web, unittest
 import stackexchange.sites as stacksites
 from stackexchange.core import StackExchangeError
-# for Python 3 compatiblity
+# for Python 3 compatibility
 try:
     import htmlentitydefs
 except ImportError:


### PR DESCRIPTION
There are small typos in:
- stackexchange/site.py
- testsuite.py

Fixes:
- Should read `objects` rather than `objectss`.
- Should read `compatibility` rather than `compatiblity`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md